### PR TITLE
Add functionality to start, stop, and destroy droplet

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ A library used to create and manage minecraft servers on DigitalOcean droplets.
 - [ ] Start Minecraft remotely
 - [ ] Stop Minecraft remotely
 - [ ] Restart Minecraft remotely
-- [ ] Shut down droplet (after stopping minecraft)
+- [x] Start droplet
+- [x] Shut down droplet (after stopping minecraft)
 - [ ] Take snapshot of droplet
-- [ ] Destroy droplet
+- [x] Destroy droplet
 
 There is likely more functionality I forgot, so we'll add that later.

--- a/program.js
+++ b/program.js
@@ -3,6 +3,9 @@ const { MinecraftService } = require('./dist');
 
 const service = new MinecraftService();
 
+// hardcode the correct id here when testing the various methods below
+const id = 172162308;
+
 const options = {
   name: 'minecraft-server',
   version: '1.15.0',
@@ -19,3 +22,15 @@ service
   .catch(err => {
     console.log(JSON.stringify(err));
   });
+
+// service.stopMinecraftServer(id).catch(err => {
+//   console.log(JSON.stringify(err));
+// });
+
+// service.startMinecraftServer(id).catch(err => {
+//   console.log(JSON.stringify(err));
+// });
+
+// service.killMinecraftServer(id).catch(err => {
+//   console.log(JSON.stringify(err));
+// });

--- a/src/services/minecraft.service.ts
+++ b/src/services/minecraft.service.ts
@@ -1,4 +1,4 @@
-import { DigitalOcean, DropletRequest, Droplet } from 'digitalocean-js';
+import { DigitalOcean, DropletRequest, Droplet, Action } from 'digitalocean-js';
 import { readFile, read } from 'fs';
 import { resolve } from 'path';
 import { promisify } from 'util';
@@ -33,6 +33,20 @@ export class MinecraftService {
     const droplet = await this.client.droplets.createNewDroplet(request);
 
     return droplet;
+  }
+
+  public async stopMinecraftServer(id: number): Promise<Action> {
+    const action = this.client.dropletActions.powerOffDroplet(id);
+    return action;
+  }
+
+  public async startMinecraftServer(id: number): Promise<Action> {
+    const action = this.client.dropletActions.powerOnDroplet(id);
+    return action;
+  }
+
+  public async killMinecraftServer(id: number): Promise<void> {
+    const droplet = this.client.droplets.deleteDroplet(id);
   }
 
   private async getScript(key: string): Promise<string> {


### PR DESCRIPTION
I also updated the README.md file. Note that the stopMinecraftServer method does not take into account whether Minecraft has been stopped or not, so we'll need to add that functionality later.