### PR TITLE
Remove env requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "axios": "^0.21.0",
-    "digitalocean-js": "^1.5.7",
-    "dotenv": "^8.2.0"
+    "digitalocean-js": "^1.5.7"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,0 @@
-import dotenv from 'dotenv';
-dotenv.config();
-
-export const env = {
-  apiKey: process.env.DIGITAL_OCEAN_API_KEY || '',
-  nodeEnv: process.env.NODE_ENV || ''
-};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,2 @@
-// Initialize config environment variables
-import './config';
-
 // Services
 export * from './services/minecraft.service';

--- a/src/services/minecraft.service.ts
+++ b/src/services/minecraft.service.ts
@@ -4,7 +4,6 @@ import { resolve } from 'path';
 import { promisify } from 'util';
 
 import { MinecraftServerConfig } from './interfaces/minecraft-server-config';
-import { env } from '../config';
 import { ResourceNotFound } from './exceptions/resource-not-found';
 import { InvalidFlavor } from './exceptions/invalid-flavor';
 import Axios from 'axios';
@@ -17,8 +16,8 @@ const asyncReadFile = promisify(readFile);
 export class MinecraftService {
   private client: DigitalOcean;
 
-  constructor() {
-    this.client = new DigitalOcean(env.apiKey);
+  constructor(apiKey: string) {
+    this.client = new DigitalOcean(apiKey);
   }
 
   public async createMinecraftDroplet(

--- a/tslint.json
+++ b/tslint.json
@@ -1,12 +1,26 @@
 {
-  "extends": ["tslint:latest", "tslint-config-prettier"],
+  "extends": [
+    "tslint:latest",
+    "tslint-config-prettier"
+  ],
   "rules": {
-    "interface-name": [true, "never-prefix"],
-    "no-implicit-dependencies": [true, "dev"],
+    "interface-name": [
+      true,
+      "never-prefix"
+    ],
+    "no-implicit-dependencies": [
+      true,
+      "dev"
+    ],
     "no-var-keyword": true,
-    "typedef": [true, "call-signature"],
+    "typedef": [
+      true,
+      "call-signature"
+    ],
     "no-empty": false,
     "ordered-imports": false,
-    "object-literal-sort-keys": false
+    "object-literal-sort-keys": false,
+    "no-any": false,
+    "no-inferrable-types": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -409,11 +409,6 @@ dir-glob@^2.2.2:
   dependencies:
     path-type "^3.0.0"
 
-dotenv@^8.2.0:
-  version "8.2.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz"
-  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
-
 error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz"


### PR DESCRIPTION
We can't use an env file for this because each api key will be different per-user. Instead we'll pass it in through the constructor.